### PR TITLE
fix: GameEnd input element now gets focus on page load

### DIFF
--- a/src/components/GameEnd/GameEnd.tsx
+++ b/src/components/GameEnd/GameEnd.tsx
@@ -116,6 +116,7 @@ export default function GameEnd(): JSX.Element {
               name="player_name" 
               maxLength={20}
               onChange={handlePlayerName}
+              autoFocus={true}
             />
             {
               nameError.profanity.error ? <p>{nameError.profanity.msg}</p> : <></>


### PR DESCRIPTION
## Description
- input element was not focusing when the GameEnd page loaded which meant the user had to spend time moving focus before being able to input their name. Now they can just input their name