### PR TITLE
fix: add basename=memory-match to createBrowseRouter

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,7 +38,9 @@ const router = createBrowserRouter([
       },
     ]
   }
-])
+], {
+  basename: "/memory-match"
+})
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement


### PR DESCRIPTION
## Description
- Add missing `basename` to `createBrowserRouter` that points to `memory-match`